### PR TITLE
Make positional embedding size configurable

### DIFF
--- a/scenic/models/tips.py
+++ b/scenic/models/tips.py
@@ -30,6 +30,7 @@ class VisionEncoder(nn.Module):
   variant: str
   pooling: str = 'tok'
   num_cls_tokens: int = 2  # TIPS defaults to 2 CLS tokens.
+  posembs: t.Tuple[int, int] = (16, 16)
   dropout_rate: float = 0.0
   attention_dropout_rate: float = 0.0
   stochastic_depth: float = 0.0
@@ -41,6 +42,7 @@ class VisionEncoder(nn.Module):
     self.encoder = vit.ViT(
         variant=self.variant,
         num_cls_tokens=self.num_cls_tokens,
+        posembs=self.posembs,
         dropout_rate=self.dropout_rate,
         attention_dropout_rate=self.attention_dropout_rate,
         stochastic_depth=self.stochastic_depth,

--- a/scenic/models/vit.py
+++ b/scenic/models/vit.py
@@ -304,6 +304,7 @@ class ViT(nn.Module):
   variant: str
   freeze_backbone: bool = False
   num_cls_tokens: int = 1
+  posembs: t.Tuple[int, int] = (16, 16)
   dropout_rate: float = 0.1
   attention_dropout_rate: float = 0.1
   stochastic_depth: float = 0.0
@@ -325,7 +326,7 @@ class ViT(nn.Module):
         patches=self.patches,
         hidden_size=self.hidden_size,
         num_cls_tokens=self.num_cls_tokens,
-        posembs=(16, 16),
+        posembs=self.posembs,
         )
     self.norm = nn.LayerNorm(name='encoder_norm')
     self.transformer = StackedTransformer(


### PR DESCRIPTION
## Summary

Replace hard-coded `(16, 16)` positional embedding size with a configurable `posembs` parameter throughout the model hierarchy.

## Changes

- **`scenic/models/tips.py`**: Add `posembs: t.Tuple[int, int] = (16, 16)` parameter to `VisionEncoder` (entry point) and pass it to `vit.ViT`.
- **`scenic/models/vit.py`**: Add `posembs: t.Tuple[int, int] = (16, 16)` parameter to the `ViT` class and use `self.posembs` instead of the hard-coded `(16, 16)` when constructing `ToTokenSequence`.

## Motivation

TIPSv2 models use `(32, 32)` positional embeddings, but the current code hard-codes `(16, 16)`. This change allows users to configure the positional embedding grid size at initialization:

```python
# TIPSv1 (default, unchanged behavior)
encoder = VisionEncoder(variant='B/14')  # posembs defaults to (16, 16)

# TIPSv2
encoder = VisionEncoder(variant='B/14', posembs=(32, 32))
```

## Backward Compatibility

The default value `(16, 16)` ensures full backward compatibility with existing TIPSv1 checkpoints and code.