### PR TITLE
Add DPT segmentation decoder module and checkpoint conversion script

### DIFF
--- a/pytorch/decoders.py
+++ b/pytorch/decoders.py
@@ -1,0 +1,214 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DPT decoder heads for dense prediction tasks (segmentation, depth, etc.)."""
+
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class PreActResidualConvUnit(nn.Module):
+  """Pre-activation residual convolution unit."""
+
+  def __init__(self, features: int) -> None:
+    super().__init__()
+    self.conv1 = nn.Conv2d(features, features, 3, padding=1, bias=False)
+    self.conv2 = nn.Conv2d(features, features, 3, padding=1, bias=False)
+
+  def forward(self, x: torch.Tensor) -> torch.Tensor:
+    residual = x
+    x = F.relu(x)
+    x = self.conv1(x)
+    x = F.relu(x)
+    x = self.conv2(x)
+    return x + residual
+
+
+class FeatureFusionBlock(nn.Module):
+  """Fuses features with optional residual input, then upsamples 2x."""
+
+  def __init__(
+      self,
+      features: int,
+      has_residual: bool = False,
+      expand: bool = False,
+  ) -> None:
+    super().__init__()
+    self.has_residual = has_residual
+    if has_residual:
+      self.residual_unit = PreActResidualConvUnit(features)
+    self.main_unit = PreActResidualConvUnit(features)
+    out_features = features // 2 if expand else features
+    self.out_conv = nn.Conv2d(features, out_features, 1, bias=True)
+
+  def forward(
+      self,
+      x: torch.Tensor,
+      residual: Optional[torch.Tensor] = None,
+  ) -> torch.Tensor:
+    if self.has_residual and residual is not None:
+      if residual.shape != x.shape:
+        residual = F.interpolate(
+            residual,
+            size=x.shape[2:],
+            mode="bilinear",
+            align_corners=False,
+        )
+      residual = self.residual_unit(residual)
+      x = x + residual
+    x = self.main_unit(x)
+    # Upsample 2x with align_corners=True (matches Scenic reference).
+    x = F.interpolate(
+        x, scale_factor=2, mode="bilinear", align_corners=True
+    )
+    x = self.out_conv(x)
+    return x
+
+
+class ReassembleBlocks(nn.Module):
+  """Projects and resizes intermediate ViT features to different scales."""
+
+  def __init__(
+      self,
+      input_embed_dim: int = 1024,
+      out_channels: Tuple[int, ...] = (128, 256, 512, 1024),
+      readout_type: str = "project",
+  ) -> None:
+    super().__init__()
+    self.readout_type = readout_type
+    self.out_projections = nn.ModuleList(
+        [nn.Conv2d(input_embed_dim, ch, 1) for ch in out_channels]
+    )
+    self.resize_layers = nn.ModuleList([
+        nn.ConvTranspose2d(
+            out_channels[0], out_channels[0], kernel_size=4, stride=4, padding=0
+        ),
+        nn.ConvTranspose2d(
+            out_channels[1], out_channels[1], kernel_size=2, stride=2, padding=0
+        ),
+        nn.Identity(),
+        nn.Conv2d(out_channels[3], out_channels[3], 3, stride=2, padding=1),
+    ])
+    if readout_type == "project":
+      self.readout_projects = nn.ModuleList([
+          nn.Linear(2 * input_embed_dim, input_embed_dim)
+          for _ in out_channels
+      ])
+
+  def forward(
+      self,
+      features: list[tuple[torch.Tensor, torch.Tensor]],
+  ) -> list[torch.Tensor]:
+    out = []
+    for i, (cls_token, x) in enumerate(features):
+      b, d, h, w = x.shape
+      if self.readout_type == "project":
+        x_flat = x.flatten(2).transpose(1, 2)
+        readout = cls_token.unsqueeze(1).expand(-1, x_flat.shape[1], -1)
+        x_cat = torch.cat([x_flat, readout], dim=-1)
+        x_proj = F.gelu(self.readout_projects[i](x_cat))
+        x = x_proj.transpose(1, 2).reshape(b, d, h, w)
+      x = self.out_projections[i](x)
+      x = self.resize_layers[i](x)
+      out.append(x)
+    return out
+
+
+class DPTSegmentationHead(nn.Module):
+  """Full DPT head + segmentation decoder."""
+
+  def __init__(
+      self,
+      input_embed_dim: int = 1024,
+      channels: int = 256,
+      post_process_channels: Tuple[int, ...] = (128, 256, 512, 1024),
+      readout_type: str = "project",
+      num_classes: int = 150,
+  ) -> None:
+    super().__init__()
+    self.reassemble = ReassembleBlocks(
+        input_embed_dim=input_embed_dim,
+        out_channels=post_process_channels,
+        readout_type=readout_type,
+    )
+    self.convs = nn.ModuleList([
+        nn.Conv2d(ch, channels, 3, padding=1, bias=False)
+        for ch in post_process_channels
+    ])
+    self.fusion_blocks = nn.ModuleList([
+        FeatureFusionBlock(channels, has_residual=False),
+        FeatureFusionBlock(channels, has_residual=True),
+        FeatureFusionBlock(channels, has_residual=True),
+        FeatureFusionBlock(channels, has_residual=True),
+    ])
+    self.project = nn.Conv2d(channels, channels, 3, padding=1, bias=True)
+    self.segmentation_head = nn.Linear(channels, num_classes)
+
+  def forward(
+      self,
+      intermediate_features: list[tuple[torch.Tensor, torch.Tensor]],
+      image_size: Optional[Tuple[int, int]] = None,
+  ) -> torch.Tensor:
+    x = self.reassemble(intermediate_features)
+    x = [self.convs[i](feat) for i, feat in enumerate(x)]
+
+    out = self.fusion_blocks[0](x[-1])
+    for i in range(1, 4):
+      out = self.fusion_blocks[i](out, residual=x[-(i + 1)])
+
+    out = self.project(out)
+    out = out.permute(0, 2, 3, 1)
+    out = self.segmentation_head(out)  # (B, H, W, num_classes)
+
+    if image_size is not None:
+      out = out.permute(0, 3, 1, 2)
+      out = F.interpolate(
+          out, size=image_size, mode="bilinear", align_corners=False
+      )
+    else:
+      out = out.permute(0, 3, 1, 2)
+    return out
+
+
+def load_segmentation_weights(
+    model: DPTSegmentationHead,
+    checkpoint_path: str,
+) -> DPTSegmentationHead:
+  """Load pre-converted PyTorch weights into a DPTSegmentationHead.
+
+  The checkpoint should be an .npz file where keys match the model's
+  state_dict parameter names and values are NumPy arrays in PyTorch layout
+  (already transposed from Flax/JAX format).
+
+  Use `scripts/convert_segmentation_checkpoint.py` to produce these
+  checkpoints from the original Flax/JAX .zip files.
+
+  Args:
+    model: A DPTSegmentationHead instance.
+    checkpoint_path: Path to a .npz checkpoint file.
+
+  Returns:
+    The model with loaded weights.
+  """
+  weights = dict(np.load(checkpoint_path, allow_pickle=False))
+  sd = {}
+  for key, value in weights.items():
+    sd[key] = torch.from_numpy(value)
+  model.load_state_dict(sd, strict=True)
+  print(f"Loaded DPT segmentation head weights ({len(sd)} tensors)")
+  return model

--- a/pytorch/decoders.py
+++ b/pytorch/decoders.py
@@ -15,7 +15,6 @@
 """DPT decoder heads for dense prediction tasks (segmentation, depth, etc.)."""
 
 from typing import Optional, Tuple
-
 import numpy as np
 import torch
 from torch import nn
@@ -129,8 +128,8 @@ class ReassembleBlocks(nn.Module):
     return out
 
 
-class DPTSegmentationHead(nn.Module):
-  """Full DPT head + segmentation decoder."""
+class DPTHead(nn.Module):
+  """DPT head producing dense features."""
 
   def __init__(
       self,
@@ -138,7 +137,6 @@ class DPTSegmentationHead(nn.Module):
       channels: int = 256,
       post_process_channels: Tuple[int, ...] = (128, 256, 512, 1024),
       readout_type: str = "project",
-      num_classes: int = 150,
   ) -> None:
     super().__init__()
     self.reassemble = ReassembleBlocks(
@@ -157,12 +155,10 @@ class DPTSegmentationHead(nn.Module):
         FeatureFusionBlock(channels, has_residual=True),
     ])
     self.project = nn.Conv2d(channels, channels, 3, padding=1, bias=True)
-    self.segmentation_head = nn.Linear(channels, num_classes)
 
   def forward(
       self,
       intermediate_features: list[tuple[torch.Tensor, torch.Tensor]],
-      image_size: Optional[Tuple[int, int]] = None,
   ) -> torch.Tensor:
     x = self.reassemble(intermediate_features)
     x = [self.convs[i](feat) for i, feat in enumerate(x)]
@@ -172,34 +168,124 @@ class DPTSegmentationHead(nn.Module):
       out = self.fusion_blocks[i](out, residual=x[-(i + 1)])
 
     out = self.project(out)
-    out = out.permute(0, 2, 3, 1)
-    out = self.segmentation_head(out)  # (B, H, W, num_classes)
-
-    if image_size is not None:
-      out = out.permute(0, 3, 1, 2)
-      out = F.interpolate(
-          out, size=image_size, mode="bilinear", align_corners=False
-      )
-    else:
-      out = out.permute(0, 3, 1, 2)
     return out
 
 
-def load_segmentation_weights(
-    model: DPTSegmentationHead,
+class Decoder(nn.Module):
+  """Base decoder class for dense prediction tasks."""
+
+  def __init__(
+      self,
+      input_embed_dim: int = 1024,
+      channels: int = 256,
+      post_process_channels: Tuple[int, ...] = (128, 256, 512, 1024),
+      readout_type: str = "project",
+  ) -> None:
+    super().__init__()
+    self.dpt = DPTHead(
+        input_embed_dim=input_embed_dim,
+        channels=channels,
+        post_process_channels=post_process_channels,
+        readout_type=readout_type,
+    )
+
+  def forward(
+      self,
+      intermediate_features: list[tuple[torch.Tensor, torch.Tensor]],
+  ) -> torch.Tensor:
+    return self.dpt(intermediate_features)
+
+
+class SegmentationDecoder(Decoder):
+  """Decoder for semantic segmentation."""
+
+  def __init__(
+      self,
+      num_classes: int = 150,
+      **kwargs,
+  ) -> None:
+    super().__init__(**kwargs)
+    channels = kwargs.get("channels", 256)
+    self.head = nn.Linear(channels, num_classes)
+
+  def forward(
+      self,
+      intermediate_features: list[tuple[torch.Tensor, torch.Tensor]],
+      image_size: Optional[Tuple[int, int]] = None,
+  ) -> torch.Tensor:
+    x = super().forward(intermediate_features)
+    x = x.permute(0, 2, 3, 1)
+    x = self.head(x)
+    x = x.permute(0, 3, 1, 2)
+    if image_size is not None:
+      x = F.interpolate(
+          x, size=image_size, mode="bilinear", align_corners=False
+      )
+    return x
+
+
+class DepthDecoder(Decoder):
+  """Decoder for depth prediction."""
+
+  def __init__(
+      self,
+      **kwargs,
+  ) -> None:
+    super().__init__(**kwargs)
+    channels = kwargs.get("channels", 256)
+    self.head = nn.Linear(channels, 1)
+
+  def forward(
+      self,
+      intermediate_features: list[tuple[torch.Tensor, torch.Tensor]],
+      image_size: Optional[Tuple[int, int]] = None,
+  ) -> torch.Tensor:
+    x = super().forward(intermediate_features)
+    x = x.permute(0, 2, 3, 1)
+    x = self.head(x)
+    x = x.permute(0, 3, 1, 2)
+    if image_size is not None:
+      x = F.interpolate(
+          x, size=image_size, mode="bilinear", align_corners=False
+      )
+    return x
+
+
+class NormalsDecoder(Decoder):
+  """Decoder for surface normals."""
+
+  def __init__(
+      self,
+      **kwargs,
+  ) -> None:
+    super().__init__(**kwargs)
+    channels = kwargs.get("channels", 256)
+    self.head = nn.Linear(channels, 3)
+
+  def forward(
+      self,
+      intermediate_features: list[tuple[torch.Tensor, torch.Tensor]],
+      image_size: Optional[Tuple[int, int]] = None,
+  ) -> torch.Tensor:
+    x = super().forward(intermediate_features)
+    x = x.permute(0, 2, 3, 1)
+    x = self.head(x)
+    x = x.permute(0, 3, 1, 2)
+    if image_size is not None:
+      x = F.interpolate(
+          x, size=image_size, mode="bilinear", align_corners=False
+      )
+    return x
+
+
+def load_decoder_weights(
+    model: Decoder,
     checkpoint_path: str,
-) -> DPTSegmentationHead:
-  """Load pre-converted PyTorch weights into a DPTSegmentationHead.
-
-  The checkpoint should be an .npz file where keys match the model's
-  state_dict parameter names and values are NumPy arrays in PyTorch layout
-  (already transposed from Flax/JAX format).
-
-  Use `scripts/convert_segmentation_checkpoint.py` to produce these
-  checkpoints from the original Flax/JAX .zip files.
+) -> Decoder:
+  """Load pre-converted PyTorch weights into a Decoder.
 
   Args:
-    model: A DPTSegmentationHead instance.
+    model: A Decoder instance (SegmentationDecoder, DepthDecoder, etc.).
     checkpoint_path: Path to a .npz checkpoint file.
 
   Returns:
@@ -208,7 +294,20 @@ def load_segmentation_weights(
   weights = dict(np.load(checkpoint_path, allow_pickle=False))
   sd = {}
   for key, value in weights.items():
-    sd[key] = torch.from_numpy(value)
+    if (
+        key.startswith("reassemble.")
+        or key.startswith("convs.")
+        or key.startswith("fusion_blocks.")
+        or key.startswith("project.")
+    ):
+      # Map to the dpt submodule
+      sd[f"dpt.{key}"] = torch.from_numpy(value)
+    elif key.startswith("segmentation_head."):
+      # Map to the head submodule in the subclass
+      sd[f"head.{key.replace('segmentation_head.', '')}"] = torch.from_numpy(
+          value
+      )
+
   model.load_state_dict(sd, strict=True)
-  print(f"Loaded DPT segmentation head weights ({len(sd)} tensors)")
+  print(f"Loaded decoder weights ({len(sd)} tensors)")
   return model

--- a/scripts/convert_segmentation_checkpoint.py
+++ b/scripts/convert_segmentation_checkpoint.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert Flax/JAX segmentation DPT checkpoints to PyTorch format.
+
+This script reads the original .zip checkpoint (containing .npy files in
+Flax/JAX weight layout) and produces a .npz file with weights transposed
+to PyTorch conventions. The output can be loaded directly by
+`tips.pytorch.decoders.load_segmentation_weights`.
+
+Usage:
+  python scripts/convert_segmentation_checkpoint.py \
+      --input_zip checkpoints/tips_v2_l14_segmentation_dpt.zip \
+      --output_npz checkpoints/tips_v2_l14_segmentation_dpt_pytorch.npz
+"""
+
+import argparse
+import io
+import zipfile
+
+import numpy as np
+
+
+def _load_npy_from_zip(zf: zipfile.ZipFile, name: str) -> np.ndarray:
+  with zf.open(name) as f:
+    return np.load(io.BytesIO(f.read()))
+
+
+def _conv_kernel_flax_to_torch(w: np.ndarray) -> np.ndarray:
+  """Convert conv kernel: (H, W, C_in, C_out) -> (C_out, C_in, H, W)."""
+  return w.transpose(3, 2, 0, 1).copy()
+
+
+def _conv_transpose_kernel_flax_to_torch(w: np.ndarray) -> np.ndarray:
+  """Convert conv-transpose kernel: (H, W, C_out, C_in) -> (C_in, C_out, H, W)."""
+  return w.transpose(2, 3, 0, 1).copy()
+
+
+def _linear_kernel_flax_to_torch(w: np.ndarray) -> np.ndarray:
+  """Convert linear kernel: (in, out) -> (out, in)."""
+  return w.T.copy()
+
+
+def _bias(w: np.ndarray) -> np.ndarray:
+  return w.copy()
+
+
+def convert_checkpoint(input_zip: str, output_npz: str) -> None:
+  """Convert a Flax/JAX segmentation DPT checkpoint to PyTorch format."""
+  zf = zipfile.ZipFile(input_zip, "r")
+  npy = lambda name: _load_npy_from_zip(zf, name)
+  sd = {}
+  prefix = "decoder/dpt/"
+
+  # --- Reassemble blocks ---
+  for i in range(4):
+    sd[f"reassemble.out_projections.{i}.weight"] = (
+        _conv_kernel_flax_to_torch(
+            npy(f"{prefix}reassemble_blocks/out_projection_{i}/kernel.npy")
+        )
+    )
+    sd[f"reassemble.out_projections.{i}.bias"] = _bias(
+        npy(f"{prefix}reassemble_blocks/out_projection_{i}/bias.npy")
+    )
+    sd[f"reassemble.readout_projects.{i}.weight"] = (
+        _linear_kernel_flax_to_torch(
+            npy(f"{prefix}reassemble_blocks/readout_projects_{i}/kernel.npy")
+        )
+    )
+    sd[f"reassemble.readout_projects.{i}.bias"] = _bias(
+        npy(f"{prefix}reassemble_blocks/readout_projects_{i}/bias.npy")
+    )
+
+  # Resize layers (0=ConvTranspose, 1=ConvTranspose, 2=Identity, 3=Conv)
+  sd["reassemble.resize_layers.0.weight"] = (
+      _conv_transpose_kernel_flax_to_torch(
+          npy(f"{prefix}reassemble_blocks/resize_layers_0/kernel.npy")
+      )
+  )
+  sd["reassemble.resize_layers.0.bias"] = _bias(
+      npy(f"{prefix}reassemble_blocks/resize_layers_0/bias.npy")
+  )
+  sd["reassemble.resize_layers.1.weight"] = (
+      _conv_transpose_kernel_flax_to_torch(
+          npy(f"{prefix}reassemble_blocks/resize_layers_1/kernel.npy")
+      )
+  )
+  sd["reassemble.resize_layers.1.bias"] = _bias(
+      npy(f"{prefix}reassemble_blocks/resize_layers_1/bias.npy")
+  )
+  sd["reassemble.resize_layers.3.weight"] = _conv_kernel_flax_to_torch(
+      npy(f"{prefix}reassemble_blocks/resize_layers_3/kernel.npy")
+  )
+  sd["reassemble.resize_layers.3.bias"] = _bias(
+      npy(f"{prefix}reassemble_blocks/resize_layers_3/bias.npy")
+  )
+
+  # --- Convs (no bias) ---
+  for i in range(4):
+    sd[f"convs.{i}.weight"] = _conv_kernel_flax_to_torch(
+        npy(f"{prefix}convs_{i}/kernel.npy")
+    )
+
+  # --- Fusion blocks ---
+  for i in range(4):
+    fb = f"{prefix}fusion_blocks_{i}/"
+    if i == 0:
+      # Block 0 has no residual unit; only main_unit (PreActResidualConvUnit_0).
+      sd[f"fusion_blocks.{i}.main_unit.conv1.weight"] = (
+          _conv_kernel_flax_to_torch(
+              npy(f"{fb}PreActResidualConvUnit_0/conv1/kernel.npy")
+          )
+      )
+      sd[f"fusion_blocks.{i}.main_unit.conv2.weight"] = (
+          _conv_kernel_flax_to_torch(
+              npy(f"{fb}PreActResidualConvUnit_0/conv2/kernel.npy")
+          )
+      )
+    else:
+      # Blocks 1-3 have both residual_unit (Unit_0) and main_unit (Unit_1).
+      sd[f"fusion_blocks.{i}.residual_unit.conv1.weight"] = (
+          _conv_kernel_flax_to_torch(
+              npy(f"{fb}PreActResidualConvUnit_0/conv1/kernel.npy")
+          )
+      )
+      sd[f"fusion_blocks.{i}.residual_unit.conv2.weight"] = (
+          _conv_kernel_flax_to_torch(
+              npy(f"{fb}PreActResidualConvUnit_0/conv2/kernel.npy")
+          )
+      )
+      sd[f"fusion_blocks.{i}.main_unit.conv1.weight"] = (
+          _conv_kernel_flax_to_torch(
+              npy(f"{fb}PreActResidualConvUnit_1/conv1/kernel.npy")
+          )
+      )
+      sd[f"fusion_blocks.{i}.main_unit.conv2.weight"] = (
+          _conv_kernel_flax_to_torch(
+              npy(f"{fb}PreActResidualConvUnit_1/conv2/kernel.npy")
+          )
+      )
+
+    # Output conv (shared by all fusion blocks).
+    sd[f"fusion_blocks.{i}.out_conv.weight"] = _conv_kernel_flax_to_torch(
+        npy(f"{fb}Conv_0/kernel.npy")
+    )
+    sd[f"fusion_blocks.{i}.out_conv.bias"] = _bias(
+        npy(f"{fb}Conv_0/bias.npy")
+    )
+
+  # --- Project conv ---
+  sd["project.weight"] = _conv_kernel_flax_to_torch(
+      npy(f"{prefix}project/kernel.npy")
+  )
+  sd["project.bias"] = _bias(npy(f"{prefix}project/bias.npy"))
+
+  # --- Segmentation head (linear) ---
+  sd["segmentation_head.weight"] = _linear_kernel_flax_to_torch(
+      npy("decoder/pixel_segmentation/kernel.npy")
+  )
+  sd["segmentation_head.bias"] = _bias(
+      npy("decoder/pixel_segmentation/bias.npy")
+  )
+
+  zf.close()
+
+  # Save as .npz with keys matching PyTorch state_dict names.
+  np.savez(output_npz, **sd)
+  print(f"Converted {len(sd)} tensors -> {output_npz}")
+
+  # Print summary.
+  for key, val in sorted(sd.items()):
+    print(f"  {key}: {val.shape} ({val.dtype})")
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Convert Flax DPT segmentation checkpoint to PyTorch format."
+  )
+  parser.add_argument(
+      "--input_zip",
+      type=str,
+      required=True,
+      help="Path to the original Flax .zip checkpoint.",
+  )
+  parser.add_argument(
+      "--output_npz",
+      type=str,
+      required=True,
+      help="Path for the output PyTorch-format .npz checkpoint.",
+  )
+  args = parser.parse_args()
+  convert_checkpoint(args.input_zip, args.output_npz)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary

This PR modularizes the DPT segmentation head from the [segmentation Colab notebook](https://colab.sandbox.google.com/drive/14aeGvw52BANQHv4hkUBqUrcgWbuMjrRO) into a reusable Python module and adds an offline weight conversion script.

### Changes

#### `pytorch/decoders.py` (NEW)
DPT segmentation head architecture extracted from the Colab notebook, following the same code style as `image_encoder.py`:

- `PreActResidualConvUnit` — Pre-activation residual conv unit
- `FeatureFusionBlock` — Feature fusion with optional residual + 2× upsample
- `ReassembleBlocks` — Projects/resizes intermediate ViT features with readout projection
- `DPTSegmentationHead` — Full pipeline: reassemble → convs → fusion cascade → segmentation
- `load_segmentation_weights()` — Loads pre-converted PyTorch `.npz` checkpoints

#### `scripts/convert_segmentation_checkpoint.py` (NEW)
Offline conversion script that:
1. Reads the original Flax/JAX `.zip` checkpoint (containing `.npy` files)
2. Transposes weights from Flax/JAX to PyTorch layout
3. Saves as `.npz` with keys matching `DPTSegmentationHead.state_dict()`

```bash
python scripts/convert_segmentation_checkpoint.py \
    --input_zip tips_v2_l14_segmentation_dpt.zip \
    --output_npz tips_v2_l14_segmentation_dpt_pytorch.npz
```

### Motivation
Previously, the Flax→PyTorch weight conversion ran online every time users loaded the segmentation notebook. By moving this conversion offline and releasing pre-converted checkpoints, we:
- Reduce notebook complexity and startup time
- Remove the `jax`/`flax` dependency for inference
- Make the DPT architecture reusable outside the notebook

### Follow-up Work
- Convert all 4 variant checkpoints (B, L, So, g) and upload to GCS
- Update the segmentation Colab to import from `tips.pytorch.decoders`
- Switch example images to HuggingFace NYUv2 samples