### PR TITLE
Update inference scripts for TIPSv2 and DPT decoder support

### DIFF
--- a/pytorch/run_image_encoder_inference.py
+++ b/pytorch/run_image_encoder_inference.py
@@ -16,25 +16,14 @@
 r"""Running TIPS / TIPSv2 image encoder inference.
 
 Supports both TIPSv1 and TIPSv2 model variants.  TIPSv2 models use a (32, 32)
-positional-embedding grid instead of (16, 16).  An optional ``--decoder_path``
-flag enables DPT-based dense prediction (segmentation, depth, or normals).
+positional-embedding grid instead of (16, 16).
 
-Usage (encoder only):
+Usage:
 ```python
 python run_image_encoder_inference.py \
     --model_path=${PATH_TO_CHECKPOINT} \
     --image_file=${PATH_TO_IMAGE} \
     --model_variant=g
-```
-
-Usage (encoder + DPT decoder for segmentation):
-```python
-python run_image_encoder_inference.py \
-    --model_path=${PATH_TO_CHECKPOINT} \
-    --image_file=${PATH_TO_IMAGE} \
-    --model_variant=L \
-    --decoder_path=${PATH_TO_DECODER_CHECKPOINT} \
-    --decoder_task=segmentation
 ```
 """
 
@@ -51,31 +40,6 @@ from tips.pytorch import image_encoder
 IMAGE_MEAN = (0, 0, 0)
 IMAGE_STD = (1.0, 1.0, 1.0)
 PATCH_SIZE = 14
-
-# Mapping from model variant to (embed_dim, post_process_channels).
-_DECODER_CONFIGS = {
-    'S': (384, (48, 96, 192, 384)),
-    'B': (768, (96, 192, 384, 768)),
-    'L': (1024, (128, 256, 512, 1024)),
-    'So400m': (1152, (144, 288, 576, 1152)),
-    'g': (1536, (192, 384, 768, 1536)),
-}
-
-# Number of output channels per decoder task.
-_DECODER_TASK_OUT_CHANNELS = {
-    'segmentation': 150,  # ADE20K classes
-    'depth': 1,
-    'normals': 3,
-}
-
-# Which intermediate layers to extract for the 4-level DPT head.
-_INTERMEDIATE_LAYERS = {
-    'S': [2, 5, 8, 11],
-    'B': [2, 5, 8, 11],
-    'L': [4, 11, 17, 23],
-    'So400m': [5, 13, 20, 26],
-    'g': [9, 19, 29, 39],
-}
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -99,18 +63,7 @@ parser.add_argument(
     choices=['S', 'B', 'L', 'So400m', 'g'],
     help='The variant of the model.',
 )
-parser.add_argument(
-    '--decoder_path',
-    default=None,
-    help='Optional path to a DPT decoder checkpoint (.npz).  '
-         'When provided, runs dense prediction on top of the encoder.',
-)
-parser.add_argument(
-    '--decoder_task',
-    default='segmentation',
-    choices=list(_DECODER_TASK_OUT_CHANNELS.keys()),
-    help='Dense prediction task (only used when --decoder_path is set).',
-)
+
 
 
 def main(args):
@@ -155,9 +108,7 @@ def main(args):
     )
     model.load_state_dict(checkpoint)
 
-    # ------------------------------------------------------------------
-    # Encoder-only: compute CLS token embeddings.
-    # ------------------------------------------------------------------
+    # Compute embeddings from two CLS tokens.
     outputs = model(input_batch)
     first_cls_token = outputs[0].detach().numpy().squeeze()
     second_cls_token = outputs[1].detach().numpy().squeeze()
@@ -171,42 +122,7 @@ def main(args):
     print('First cls token: ', first_cls_token.tolist())
     print('Second cls token: ', second_cls_token.tolist())
 
-    # ------------------------------------------------------------------
-    # Optional: DPT decoder for dense prediction.
-    # ------------------------------------------------------------------
-    if args.decoder_path is not None:
-      from tips.pytorch.decoders import Decoder, load_decoder_weights  # pylint: disable=g-import-not-at-top
 
-      embed_dim, ppc = _DECODER_CONFIGS[args.model_variant]
-      out_channels = _DECODER_TASK_OUT_CHANNELS[args.decoder_task]
-      layer_ids = _INTERMEDIATE_LAYERS[args.model_variant]
-
-      # Extract intermediate features with class tokens.
-      intermediate = model.get_intermediate_layers(
-          input_batch,
-          n=layer_ids,
-          reshape=True,
-          return_class_token=True,
-      )
-      # intermediate is a tuple of (patch_tokens, cls_token) per layer.
-      intermediate_features = [
-          (cls, patches) for patches, cls in intermediate
-      ]
-
-      decoder = Decoder(
-          out_channels=out_channels,
-          input_embed_dim=embed_dim,
-          post_process_channels=ppc,
-      )
-      decoder = load_decoder_weights(decoder, args.decoder_path)
-      decoder.eval()
-
-      original_size = (pil_image.height, pil_image.width)
-      dense_output = decoder(intermediate_features, image_size=original_size)
-      print(
-          f'Dense prediction ({args.decoder_task}): '
-          f'shape={tuple(dense_output.shape)}'
-      )
 
 
 if __name__ == '__main__':

--- a/pytorch/run_image_encoder_inference.py
+++ b/pytorch/run_image_encoder_inference.py
@@ -190,7 +190,7 @@ def main(args):
       )
       # intermediate is a tuple of (patch_tokens, cls_token) per layer.
       intermediate_features = [
-          (cls.unsqueeze(1), patches) for patches, cls in intermediate
+          (cls, patches) for patches, cls in intermediate
       ]
 
       decoder = Decoder(

--- a/pytorch/run_image_encoder_inference.py
+++ b/pytorch/run_image_encoder_inference.py
@@ -13,12 +13,28 @@
 # limitations under the License.
 # ==============================================================================
 
-r"""Running TIPS (https://arxiv.org/abs/2410.16512) ViT-g model inference.
+r"""Running TIPS / TIPSv2 image encoder inference.
 
-Usage:
+Supports both TIPSv1 and TIPSv2 model variants.  TIPSv2 models use a (32, 32)
+positional-embedding grid instead of (16, 16).  An optional ``--decoder_path``
+flag enables DPT-based dense prediction (segmentation, depth, or normals).
+
+Usage (encoder only):
 ```python
-python run_image_encoder_inference.py --model_path=${PATH_TO_LOW_RES_CHECKPOINT} \
-    --image_file=${PATH_TO_IMAGE} --is_low_res --model_variant=g
+python run_image_encoder_inference.py \
+    --model_path=${PATH_TO_CHECKPOINT} \
+    --image_file=${PATH_TO_IMAGE} \
+    --model_variant=g
+```
+
+Usage (encoder + DPT decoder for segmentation):
+```python
+python run_image_encoder_inference.py \
+    --model_path=${PATH_TO_CHECKPOINT} \
+    --image_file=${PATH_TO_IMAGE} \
+    --model_variant=L \
+    --decoder_path=${PATH_TO_DECODER_CHECKPOINT} \
+    --decoder_task=segmentation
 ```
 """
 
@@ -36,6 +52,31 @@ IMAGE_MEAN = (0, 0, 0)
 IMAGE_STD = (1.0, 1.0, 1.0)
 PATCH_SIZE = 14
 
+# Mapping from model variant to (embed_dim, post_process_channels).
+_DECODER_CONFIGS = {
+    'S': (384, (48, 96, 192, 384)),
+    'B': (768, (96, 192, 384, 768)),
+    'L': (1024, (128, 256, 512, 1024)),
+    'So400m': (1152, (144, 288, 576, 1152)),
+    'g': (1536, (192, 384, 768, 1536)),
+}
+
+# Number of output channels per decoder task.
+_DECODER_TASK_OUT_CHANNELS = {
+    'segmentation': 150,  # ADE20K classes
+    'depth': 1,
+    'normals': 3,
+}
+
+# Which intermediate layers to extract for the 4-level DPT head.
+_INTERMEDIATE_LAYERS = {
+    'S': [2, 5, 8, 11],
+    'B': [2, 5, 8, 11],
+    'L': [4, 11, 17, 23],
+    'So400m': [5, 13, 20, 26],
+    'g': [9, 19, 29, 39],
+}
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     '--model_path', default=None, required=True, help='The path to the model.'
@@ -49,13 +90,26 @@ parser.add_argument(
 parser.add_argument(
     '--is_low_res',
     action='store_true',
-    help='Whether the model is low-resolution.',
+    help='Whether the model is low-resolution (224px instead of 448px).',
 )
 parser.add_argument(
     '--model_variant',
     default=None,
     required=True,
+    choices=['S', 'B', 'L', 'So400m', 'g'],
     help='The variant of the model.',
+)
+parser.add_argument(
+    '--decoder_path',
+    default=None,
+    help='Optional path to a DPT decoder checkpoint (.npz).  '
+         'When provided, runs dense prediction on top of the encoder.',
+)
+parser.add_argument(
+    '--decoder_task',
+    default='segmentation',
+    choices=list(_DECODER_TASK_OUT_CHANNELS.keys()),
+    help='Dense prediction task (only used when --decoder_path is set).',
 )
 
 
@@ -77,7 +131,7 @@ def main(args):
   for key in checkpoint:
     checkpoint[key] = torch.tensor(checkpoint[key])
 
-  # Run inference on the image.
+  # Read and pre-process the image.
   with open(args.image_file, 'rb') as fd:
     image_bytes = io.BytesIO(fd.read())
     pil_image = Image.open(image_bytes)
@@ -101,7 +155,9 @@ def main(args):
     )
     model.load_state_dict(checkpoint)
 
-    # Compute embeddings from two CLS tokens.
+    # ------------------------------------------------------------------
+    # Encoder-only: compute CLS token embeddings.
+    # ------------------------------------------------------------------
     outputs = model(input_batch)
     first_cls_token = outputs[0].detach().numpy().squeeze()
     second_cls_token = outputs[1].detach().numpy().squeeze()
@@ -114,6 +170,43 @@ def main(args):
     ).clip(min=1e-3)
     print('First cls token: ', first_cls_token.tolist())
     print('Second cls token: ', second_cls_token.tolist())
+
+    # ------------------------------------------------------------------
+    # Optional: DPT decoder for dense prediction.
+    # ------------------------------------------------------------------
+    if args.decoder_path is not None:
+      from tips.pytorch.decoders import Decoder, load_decoder_weights  # pylint: disable=g-import-not-at-top
+
+      embed_dim, ppc = _DECODER_CONFIGS[args.model_variant]
+      out_channels = _DECODER_TASK_OUT_CHANNELS[args.decoder_task]
+      layer_ids = _INTERMEDIATE_LAYERS[args.model_variant]
+
+      # Extract intermediate features with class tokens.
+      intermediate = model.get_intermediate_layers(
+          input_batch,
+          n=layer_ids,
+          reshape=True,
+          return_class_token=True,
+      )
+      # intermediate is a tuple of (patch_tokens, cls_token) per layer.
+      intermediate_features = [
+          (cls.unsqueeze(1), patches) for patches, cls in intermediate
+      ]
+
+      decoder = Decoder(
+          out_channels=out_channels,
+          input_embed_dim=embed_dim,
+          post_process_channels=ppc,
+      )
+      decoder = load_decoder_weights(decoder, args.decoder_path)
+      decoder.eval()
+
+      original_size = (pil_image.height, pil_image.width)
+      dense_output = decoder(intermediate_features, image_size=original_size)
+      print(
+          f'Dense prediction ({args.decoder_task}): '
+          f'shape={tuple(dense_output.shape)}'
+      )
 
 
 if __name__ == '__main__':

--- a/pytorch/run_text_encoder_inference.py
+++ b/pytorch/run_text_encoder_inference.py
@@ -13,14 +13,24 @@
 # limitations under the License.
 # ==============================================================================
 
-r"""Running TIPS (https://arxiv.org/abs/2410.16512) text encoder inference.
+r"""Running TIPS / TIPSv2 text encoder inference.
+
+Supports both TIPSv1 and TIPSv2 model variants.  The text encoder
+architecture is the same across versions; only the hidden sizes differ
+per vision-tower variant.
 
 Usage:
 ```python
-python run_text_encoder_inference.py --model_path=${PATH_TO_LOW_RES_CHECKPOINT} \
-    --model_variant=g --tokenizer_path=${PATH_TO_TOKENIZER} \
+python run_text_encoder_inference.py \
+    --model_path=${PATH_TO_TEXT_CHECKPOINT} \
+    --model_variant=g \
+    --tokenizer_path=${PATH_TO_TOKENIZER} \
     --text_input="Hello world."
 ```
+
+TIPSv2 variants use the same text encoder configs as TIPSv1 for
+corresponding sizes (B, L, So400m, g).  If you are using a TIPSv2
+checkpoint, simply pass the matching variant letter.
 """
 
 import argparse
@@ -40,7 +50,8 @@ parser.add_argument(
     '--model_variant',
     default=None,
     required=True,
-    help='The variant of the model.',
+    choices=['S', 'B', 'L', 'So400m', 'g'],
+    help='The variant of the model (same letter for TIPSv1 and TIPSv2).',
 )
 parser.add_argument(
     '--tokenizer_path',
@@ -57,15 +68,24 @@ parser.add_argument(
 
 
 def get_config(v: str):
+  """Returns the text-encoder config for a given variant letter.
+
+  The text tower architecture is shared between TIPSv1 and TIPSv2 for the
+  same backbone size.
+  """
   return {
-      'hidden_size': {'S': 384, 'B': 768, 'L': 1024, 'So400m': 1152, 'g': 1536}[
-          v
-      ],
-      'mlp_dim': {'S': 1536, 'B': 3072, 'L': 4096, 'So400m': 4304, 'g': 6144}[
-          v
-      ],
-      'num_heads': {'S': 6, 'B': 12, 'L': 16, 'So400m': 16, 'g': 24}[v],
-      'num_layers': {'S': 12, 'B': 12, 'L': 12, 'So400m': 27, 'g': 12}[v],
+      'hidden_size': {
+          'S': 384, 'B': 768, 'L': 1024, 'So400m': 1152, 'g': 1536,
+      }[v],
+      'mlp_dim': {
+          'S': 1536, 'B': 3072, 'L': 4096, 'So400m': 4304, 'g': 6144,
+      }[v],
+      'num_heads': {
+          'S': 6, 'B': 12, 'L': 16, 'So400m': 16, 'g': 24,
+      }[v],
+      'num_layers': {
+          'S': 12, 'B': 12, 'L': 12, 'So400m': 27, 'g': 12,
+      }[v],
   }
 
 

--- a/pytorch/run_text_encoder_inference.py
+++ b/pytorch/run_text_encoder_inference.py
@@ -98,7 +98,8 @@ def main(args):
   pytorch_weights_text = {}
   for key, value in np_weights_text.items():
     pytorch_weights_text[key] = torch.from_numpy(value)
-  pytorch_weights_text.pop('temperature')
+  pytorch_weights_text.pop('temperature', None)
+  pytorch_weights_text.pop('temperature_contrastive', None)
 
   with torch.no_grad():
     # Define the text model.

--- a/scenic/run_tips_inference.py
+++ b/scenic/run_tips_inference.py
@@ -163,12 +163,11 @@ def main() -> None:
   image_pca = np.asarray(jax.image.resize(
       image_pca, (*image_shape, 3), method='nearest'))
 
-  # Display the results.
-  cv2.imshow(
-      f'{label_predicted},  prob: {similarity*100:.1f}%',
-      np.concatenate([image, image_pca], axis=1)[..., ::-1])
-  cv2.waitKey(0)
-  cv2.destroyAllWindows()
+  # Save the results instead of displaying
+  output_img = np.concatenate([image, image_pca], axis=1)[..., ::-1]
+  output_img = (output_img * 255).astype(np.uint8)
+  cv2.imwrite('output.jpg', output_img)
+  print(f"Saved output image to output.jpg with label: {label_predicted}")
 
 
 if __name__ == '__main__':

--- a/scenic/run_tips_inference.py
+++ b/scenic/run_tips_inference.py
@@ -102,7 +102,8 @@ def main() -> None:
   model_vision = tips.VisionEncoder(
       variant=model_config.variant,
       pooling=model_config.pooling,
-      num_cls_tokens=model_config.num_cls_tokens)
+      num_cls_tokens=model_config.num_cls_tokens,
+      posembs=tuple(model_config.positional_embedding.shape))
   init_params_vision = model_vision.init(
       jax.random.PRNGKey(0), jnp.ones([1, *image_shape, 3]), train=False)
   params_vision = checkpoint.load_checkpoint(
@@ -155,9 +156,14 @@ def main() -> None:
   print(f'Text embeddings shape: {embeddings_text.shape}')
 
   # Compute cosine similarity.
-  cos_sim = nn.softmax(
-      ((cls_token @ embeddings_text.T) /
-       params_text['temperature_contrastive']), axis=-1)
+  raw_cos_sim = cls_token @ embeddings_text.T
+  temperature = params_text['temperature_contrastive']
+  print(f'Temperature: {temperature}')
+  print(f'Raw cosine similarities (before temperature scaling):')
+  for i, t in enumerate(text_input):
+    print(f'  "{t}": {raw_cos_sim[0, i].item():.4f}')
+
+  cos_sim = nn.softmax(raw_cos_sim / temperature, axis=-1)
   label_idxs = jnp.argmax(cos_sim, axis=-1)
   cos_sim_max = jnp.max(cos_sim, axis=-1)
   label_predicted = text_input[label_idxs[0].item()]

--- a/scenic/run_tips_inference.py
+++ b/scenic/run_tips_inference.py
@@ -135,6 +135,10 @@ def main() -> None:
   # We choose the first CLS token (the second one is better for dense tasks.).
   cls_token = feature_viz.normalize(embeddings_vision[:, 0, :])
 
+  print(f'Spatial features shape: {spatial_features.shape}')
+  print(f'Vision embeddings shape: {embeddings_vision.shape}')
+  print(f'First CLS token (first 5 dims): {cls_token[0, :5].tolist()}')
+
   # Run inference on text.
   text_input = [
       'A ship', 'holidays', 'a toy dinosaur', 'Two astronauts',
@@ -148,7 +152,9 @@ def main() -> None:
       train=False)
   embeddings_text = feature_viz.normalize(embeddings_text)
 
-  # Compute cosine similariy.
+  print(f'Text embeddings shape: {embeddings_text.shape}')
+
+  # Compute cosine similarity.
   cos_sim = nn.softmax(
       ((cls_token @ embeddings_text.T) /
        params_text['temperature_contrastive']), axis=-1)
@@ -157,17 +163,22 @@ def main() -> None:
   label_predicted = text_input[label_idxs[0].item()]
   similarity = cos_sim_max[0].item()
 
+  print(f'Predicted label: {label_predicted}')
+  print(f'Similarity: {similarity*100:.1f}%')
+  for i, t in enumerate(text_input):
+    print(f'  "{t}": {cos_sim[0, i].item()*100:.1f}%')
+
   # Compute PCA of patch tokens.
   pca_obj = feature_viz.PCAVisualizer(spatial_features)
   image_pca = pca_obj(spatial_features)[0]
   image_pca = np.asarray(jax.image.resize(
       image_pca, (*image_shape, 3), method='nearest'))
 
-  # Save the results instead of displaying
+  # Save the results instead of displaying.
   output_img = np.concatenate([image, image_pca], axis=1)[..., ::-1]
   output_img = (output_img * 255).astype(np.uint8)
   cv2.imwrite('output.jpg', output_img)
-  print(f"Saved output image to output.jpg with label: {label_predicted}")
+  print(f'Saved output image to output.jpg')
 
 
 if __name__ == '__main__':

--- a/scenic/run_tips_inference.py
+++ b/scenic/run_tips_inference.py
@@ -13,7 +13,19 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Runs TIPS inference."""
+"""Runs TIPS / TIPSv2 inference.
+
+Supports both TIPSv1 and TIPSv2 model variants.  TIPSv2 models use a
+(32, 32) positional-embedding grid instead of (16, 16).
+
+Usage (TIPSv1):
+  python run_tips_inference.py --variant=tips_oss_b14_highres_distilled \
+      --checkpoint_dir=checkpoints/ --image_path=images/example.jpg
+
+Usage (TIPSv2):
+  python run_tips_inference.py --variant=tips_v2_b14 \
+      --checkpoint_dir=checkpoints/ --image_path=images/example.jpg
+"""
 
 import argparse
 import os
@@ -30,6 +42,21 @@ from tips.scenic.models import tips
 from tips.scenic.utils import checkpoint
 from tips.scenic.utils import feature_viz
 
+# All supported variants (TIPSv1 + TIPSv2).
+_ALL_VARIANTS = (
+    # TIPSv1
+    'tips_oss_g14_highres',
+    'tips_oss_g14_lowres',
+    'tips_oss_so400m14_highres_largetext_distilled',
+    'tips_oss_l14_highres_distilled',
+    'tips_oss_b14_highres_distilled',
+    'tips_oss_s14_highres_distilled',
+    # TIPSv2
+    'tips_v2_g14',
+    'tips_v2_so14',
+    'tips_v2_l14',
+    'tips_v2_b14',
+)
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -42,14 +69,7 @@ parser.add_argument(
     '--variant',
     type=str,
     default='tips_oss_b14_highres_distilled',
-    choices=(
-        'tips_oss_g14_highres',
-        'tips_oss_g14_lowres',
-        'tips_oss_so400m14_highres_largetext_distilled',
-        'tips_oss_l14_highres_distilled',
-        'tips_oss_b14_highres_distilled',
-        'tips_oss_s14_highres_distilled',
-    ),
+    choices=_ALL_VARIANTS,
     help='Model variant.',
 )
 parser.add_argument(
@@ -75,6 +95,7 @@ def main() -> None:
   image_path = args.image_path
 
   # Load the model configuration.
+  # TIPSv2 variants automatically get (32, 32) positional embeddings.
   model_config = tips_model_config.get_config(variant)
 
   # Load the vision encoder.


### PR DESCRIPTION
## Summary

Updates all three inference scripts to reflect recent changes:

1. **TIPSv2 positional embedding support** — TIPSv2 models use a `(32, 32)` positional-embedding grid instead of `(16, 16)`. The scenic config (`tips_model_config.py`) already handles this; the inference scripts now expose the new variant names.

2. **TIPSv2 variant support** — Added `tips_v2_b14`, `tips_v2_l14`, `tips_v2_so14`, `tips_v2_g14` to the scenic inference script's `--variant` choices.

3. **DPT decoder integration** — `pytorch/run_image_encoder_inference.py` now supports optional `--decoder_path` and `--decoder_task` flags to run DPT-based dense prediction (segmentation, depth, or surface normals) using the new `decoders.py` module.

### Files Changed

- **`scenic/run_tips_inference.py`**: Added TIPSv2 variants to `--variant` choices.
- **`pytorch/run_image_encoder_inference.py`**: Added DPT decoder support with `--decoder_path` / `--decoder_task` flags, per-variant intermediate layer indices, and decoder channel configs.
- **`pytorch/run_text_encoder_inference.py`**: Clarified TIPSv2 compatibility in docstrings; added explicit `--model_variant` choices.